### PR TITLE
Remove @logger.catch decorators and make loguru an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,13 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "loguru>=0.7.3",
     "python-dateutil>=2.9.0.post0",
     "python-dotenv>=1.1.0",
     "sqlmodel>=0.0.24",
 ]
+
+[project.optional-dependencies]
+loguru = ["loguru>=0.7.3"]
 [project.urls]
 "Homepage" = "https://fsecada01.github.io/SQLModel-CRUD-Utilities/sqlmodel_crud_utils.html"
 "Repository" = "https://github.com/fsecada01/sqlmodel_crud_utils"

--- a/sqlmodel_crud_utils/a_sync.py
+++ b/sqlmodel_crud_utils/a_sync.py
@@ -4,21 +4,24 @@ from typing import Type
 
 from dateutil.parser import parse as date_parse
 from dotenv import load_dotenv
-from loguru import logger
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import lazyload, selectinload
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel.sql.expression import SelectOfScalar
 
-from sqlmodel_crud_utils.utils import get_sql_dialect_import, get_val, is_date
+from sqlmodel_crud_utils.utils import (
+    get_sql_dialect_import,
+    get_val,
+    is_date,
+    logger,
+)
 
 load_dotenv()  # take environment variables from .env.
 
 upsert = get_sql_dialect_import(dialect=get_val("SQL_DIALECT"))
 
 
-@logger.catch
 async def get_result_from_query(query: SelectOfScalar, session: AsyncSession):
     """
     Processes an SQLModel query object and returns a singular result from the
@@ -40,7 +43,6 @@ async def get_result_from_query(query: SelectOfScalar, session: AsyncSession):
     return results
 
 
-@logger.catch
 async def get_one_or_create(
     session_inst: AsyncSession,
     model: type[SQLModel],
@@ -90,7 +92,6 @@ async def get_one_or_create(
         return created, False
 
 
-@logger.catch
 async def write_row(data_row: Type[SQLModel], session_inst: AsyncSession):
     """
     Writes a new instance of an SQLModel ORM model to the database, with an
@@ -115,7 +116,6 @@ async def write_row(data_row: Type[SQLModel], session_inst: AsyncSession):
         return False, None
 
 
-@logger.catch
 async def insert_data_rows(data_rows, session_inst: AsyncSession):
     """
 
@@ -157,7 +157,6 @@ async def insert_data_rows(data_rows, session_inst: AsyncSession):
         return status, {"success": processed_rows, "failed": failed_rows}
 
 
-@logger.catch
 async def get_row(
     id_str: str or int,
     session_inst: AsyncSession,
@@ -204,7 +203,6 @@ async def get_row(
     return success, row
 
 
-@logger.catch
 async def get_rows(
     session_inst: AsyncSession,
     model: type[SQLModel],
@@ -417,7 +415,6 @@ async def get_rows(
     return success, results
 
 
-@logger.catch
 async def get_rows_within_id_list(
     id_str_list: list[str | int],
     session_inst: AsyncSession,
@@ -443,7 +440,6 @@ async def get_rows_within_id_list(
     return success, results
 
 
-@logger.catch
 async def delete_row(
     id_str: str or int,
     session_inst: AsyncSession,
@@ -481,7 +477,6 @@ async def delete_row(
     return success
 
 
-@logger.catch
 async def bulk_upsert_mappings(
     payload: list,
     session_inst: AsyncSession,
@@ -514,7 +509,6 @@ async def bulk_upsert_mappings(
     return True, results.all()
 
 
-@logger.catch
 async def update_row(
     id_str: int | str,
     data: dict,

--- a/sqlmodel_crud_utils/sync.py
+++ b/sqlmodel_crud_utils/sync.py
@@ -4,20 +4,23 @@ from typing import Type
 
 from dateutil.parser import parse as date_parse
 from dotenv import load_dotenv
-from loguru import logger
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import lazyload, selectinload
 from sqlmodel import Session, SQLModel, select
 from sqlmodel.sql.expression import SelectOfScalar
 
-from sqlmodel_crud_utils.utils import get_sql_dialect_import, get_val, is_date
+from sqlmodel_crud_utils.utils import (
+    get_sql_dialect_import,
+    get_val,
+    is_date,
+    logger,
+)
 
 load_dotenv()  # take environment variables from .env.
 
 upsert = get_sql_dialect_import(dialect=get_val("SQL_DIALECT"))
 
 
-@logger.catch
 def get_result_from_query(query: SelectOfScalar, session: Session):
     """
     Processes an SQLModel query object and returns a singular result from the
@@ -39,7 +42,6 @@ def get_result_from_query(query: SelectOfScalar, session: Session):
     return results
 
 
-@logger.catch
 def get_one_or_create(
     session_inst: Session,
     model: type[SQLModel],
@@ -89,7 +91,6 @@ def get_one_or_create(
         return created, False
 
 
-@logger.catch
 def write_row(data_row: Type[SQLModel], session_inst: Session):
     """
     Writes a new instance of an SQLModel ORM model to the database, with an
@@ -114,7 +115,6 @@ def write_row(data_row: Type[SQLModel], session_inst: Session):
         return False, None
 
 
-@logger.catch
 def insert_data_rows(data_rows, session_inst: Session):
     """
 
@@ -154,7 +154,6 @@ def insert_data_rows(data_rows, session_inst: Session):
         return status, {"success": processed_rows, "failed": failed_rows}
 
 
-@logger.catch
 def get_row(
     id_str: str or int,
     session_inst: Session,
@@ -201,7 +200,6 @@ def get_row(
     return success, row
 
 
-@logger.catch
 def get_rows(
     session_inst: Session,
     model: type[SQLModel],
@@ -414,7 +412,6 @@ def get_rows(
     return success, results
 
 
-@logger.catch
 def get_rows_within_id_list(
     id_str_list: list[str | int],
     session_inst: Session,
@@ -444,7 +441,6 @@ def get_rows_within_id_list(
     return success, results
 
 
-@logger.catch
 def delete_row(
     id_str: str or int,
     session_inst: Session,
@@ -482,7 +478,6 @@ def delete_row(
     return success
 
 
-@logger.catch
 def bulk_upsert_mappings(
     payload: list,
     session_inst: Session,
@@ -515,7 +510,6 @@ def bulk_upsert_mappings(
     return True, results.all()
 
 
-@logger.catch
 def update_row(
     id_str: int | str,
     data: dict,

--- a/sqlmodel_crud_utils/utils.py
+++ b/sqlmodel_crud_utils/utils.py
@@ -1,7 +1,13 @@
 import importlib
+import logging
 import os
 
 from dateutil.parser import parse as date_parse
+
+try:
+    from loguru import logger
+except ImportError:
+    logger = logging.getLogger("sqlmodel_crud_utils")
 
 
 def get_val(val: str):


### PR DESCRIPTION
@logger.catch silently swallows exceptions and returns None, preventing
proper error propagation to callers. This is unsuitable for production
where frameworks need exceptions to flow for proper HTTP responses,
retries, and observability. The existing try/except blocks already
provide targeted error handling with session rollback and explicit
logger.error() calls where needed.

Loguru is now an optional dependency (pip install sqlmodel_crud_utils[loguru])
so teams using their own logging/telemetry can use stdlib logging instead.
The logger in utils.py falls back to logging.getLogger() when loguru is
not installed.

https://claude.ai/code/session_01G7xKgBPQia81rZHBU6BxCG